### PR TITLE
Allow this gem to work in Rails 5

### DIFF
--- a/jquery-scrollto-rails.gemspec
+++ b/jquery-scrollto-rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "jquery-scrollto-rails"
 
-  s.add_dependency "railties", "> 3.1", "< 5.0"
+  s.add_dependency "railties", "> 3.1", "< 6.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This gem is already compatible with Rails 5. This PR just updates the dependency to allow that.
